### PR TITLE
[OFFAPPS-484][ZD#1087829]Use HTML URL to redirect to articles, open a new tab on click

### DIFF
--- a/templates/results.hdbs
+++ b/templates/results.hdbs
@@ -14,7 +14,7 @@
 
         {{#if is_article}}
           <tr>
-            <td><a href="/hc/articles/{{this.id}}">{{this.name}}</a></td>
+            <td><a href="{{this.html_url}}" target="_blank">{{this.name}}</a></td>
             <td class="type">{{t "search.result_type.article"}}</td>
           </tr>
         {{/if}}


### PR DESCRIPTION
:koala: 
/cc @zendesk/quokka, @pmgrove 

![hostmapurl](https://cloud.githubusercontent.com/assets/10393846/7695198/1d4b158c-fe2f-11e4-881d-19df3c974344.gif)

### Description
We would like articles to have hostmapped URL's if the user has set hostmap settings in Lotus, however this PR only grabs and uses the "html_url" field which is seemingly already a hostmapped URL if they have it enabled.

### References
JIRA Link - https://zendesk.atlassian.net/browse/OFFAPPS-484
Support Ticket - https://support.zendesk.com/agent/tickets/1087829

### Risks
None known . . . yet