### PR TITLE
ZD2469307 Display suggestions on init

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,8 +67,8 @@
       }
 
       _.defer((function() {
-        this.trigger('requiredProperties.ready');
         this.switchTo('search');
+        this.trigger('requiredProperties.ready');
       }).bind(this));
     },
 


### PR DESCRIPTION
### Description

When the app loads initially, suggestions are not displayed. However, when the bound ticket field is changed, the suggestions appear.

It turns out the suggestions are loaded, but somehow do not appear due to the rendering order: switching the template *after* rendering the template seems to overwrite the suggestions. This PR just switches the rendering order.

/cc @zendesk/sustaining @zendesk/vegemite 

### References

* https://support.zendesk.com/agent/tickets/2469307

### Risks

Low: Just switches the rendering order on app init.