### PR TITLE
ZD2585944 Fixed Windows select padding issue

### DIFF
--- a/app.css
+++ b/app.css
@@ -76,6 +76,7 @@
 select {
   border: 1px solid lightGrey;
   height: 25px;
+  padding-top: 0px;
 }
 
 .date {


### PR DESCRIPTION
Select drop down fields would be filled with padding on top of the text, pushing it down resulting in cropped text.

With this fix I specify padding-top to be zero. This fixes the issue in browsers running on Windows, and changes nothing on Mac (where it works fine). Also fixes similar issues for the select fields shown after clicking the 'Advanced'-menu.

@zendesk/vegemite @zendesk/sustaining 

**Before:**
![before](https://cloud.githubusercontent.com/assets/981723/25803351/b5a74a18-33f6-11e7-96ed-5d63899ef20d.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/981723/25803358/be064204-33f6-11e7-8dfe-90f9cdf9f050.png)

### References:
https://support.zendesk.com/agent/tickets/2585944

### Risks:
Low: Very low risk of styling issues. 