### PR TITLE
[OFFAPPS-1028] Update toggle text colour & Fix tooltip cutoff

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -43,6 +43,7 @@ div.c-txt__input {
 }
 .c-chk__input {
   & ~ label {
+    color: var(--zd-color-blue-600);
     cursor: pointer;
     &:hover {
       text-decoration: underline;
@@ -81,7 +82,7 @@ div.c-txt__input {
       .c-tooltip {
         display: none;
         font-size: 12px;
-        left: 120px;
+        left: 115px;
         padding: 10px;
         position: absolute;
         top: 50%;


### PR DESCRIPTION
[OFFAPPS-1028] [Sidebar Search] Update toggle text colour & Fix tooltip cutoff

## Tasks
- [x] Update `Advanced` link color to be blue-600
- [x] Fix tooltip cut off issue

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1028)

## Screenshots
###Before
![Before](https://lh3.googleusercontent.com/u/0/d/1-2WqViCRA2KkDU-KjDkrNCogVgn8eVfN=w4600-h2680-iv1)
###After
![After](https://lh3.googleusercontent.com/u/0/d/1-1jmiozYezNgarwzm2wb0k4heWJxWDtd=w4600-h1736-iv1)


## CCs
@zendesk/apps-migration 
@m-lai 
