### PR TITLE
[OFFAPPS-1029] Clicking ticket ID, does not routeTo ticket page

### DIFF
--- a/spec/search.spec.js
+++ b/spec/search.spec.js
@@ -226,18 +226,20 @@ describe('Search App', () => {
 
     it('should open a new ticket when ticket result link is clicked', (done) => {
       app._client.request.mockReturnValue(Promise.resolve(RESULTS_1))
+      app._client.invoke = jest.fn()
       app._doTheSearch(new CustomEvent('fake')).then(() => {
         document.querySelector('.ticket-link').click()
-        expect(CLIENT.invoke).toHaveBeenCalledWith('routeTo', 'ticket', '1')
+        expect(app._client.invoke).toHaveBeenCalledWith('routeTo', 'ticket', '1')
         done()
       })
     })
 
     it('should open a new ticket when ticket result ID is clicked', (done) => {
       app._client.request.mockReturnValue(Promise.resolve(RESULTS_1))
+      app._client.invoke = jest.fn()
       app._doTheSearch(new CustomEvent('fake')).then(() => {
-        document.querySelector('.ticket-link b').dispatchEvent(new CustomEvent('click', {bubbles: true}))
-        expect(CLIENT.invoke).toHaveBeenCalledWith('routeTo', 'ticket', '1')
+        document.querySelector('.ticket-link b').click()
+        expect(app._client.invoke).toHaveBeenCalledWith('routeTo', 'ticket', '1')
         done()
       })
     })

--- a/spec/search.spec.js
+++ b/spec/search.spec.js
@@ -233,6 +233,15 @@ describe('Search App', () => {
       })
     })
 
+    it('should open a new ticket when ticket result ID is clicked', (done) => {
+      app._client.request.mockReturnValue(Promise.resolve(RESULTS_1))
+      app._doTheSearch(new CustomEvent('fake')).then(() => {
+        document.querySelector('.ticket-link b').dispatchEvent(new CustomEvent('click', {bubbles: true}))
+        expect(CLIENT.invoke).toHaveBeenCalledWith('routeTo', 'ticket', '1')
+        done()
+      })
+    })
+
     it('should compose search terms from form fields', (done) => {
       app._keywordField.value = 'TestKeyword'
       expect(app._getSearchParams()).toBe('TestKeyword')

--- a/src/javascript/modules/search.js
+++ b/src/javascript/modules/search.js
@@ -141,7 +141,7 @@ class Search {
     if (target === this._searchButton || target.parentNode === this._searchButton) this._doTheSearch(event)
     else if (target.classList.contains('suggestion')) this._handleSuggestionClick(event)
     else if (target.classList.contains('page-link') && target.dataset.index) this._doTheSearch(event, target.dataset.index)
-    else if (target.classList.contains('ticket-link')) this._handleResultLinkClick(event)
+    else if (target.classList.contains('ticket-link') || target.parentNode.classList.contains('ticket-link')) this._handleResultLinkClick(event)
   }
 
   /**

--- a/src/templates/results.js
+++ b/src/templates/results.js
@@ -5,7 +5,7 @@ const getTicketMarkup = (o) => {
     `
     <tr class="c-table__row">
       <td class="c-table__row__cell u-position-relative">
-        <a href class="ticket-link" data-id="${o.id}"><b>#${o.id}</b> ${escape(o.subject)}</a>
+        <a href class="ticket-link" data-id="${o.id}"><b data-id="${o.id}">#${o.id}</b> ${escape(o.subject)}</a>
         <div class="c-tooltip c-tooltip--large c-arrow c-arrow--l">${escape(o.description)}</div>
       </td>
       <td class="type c-table__row__cell u-ta-right">${I18n.t('search.result_type.ticket')}</td>


### PR DESCRIPTION
[OFFAPPS-1029] Update event handler to handle click on ticket ID

## Description
Ticket ID is wrapped in `<b></b>` which is not handled by click event delegation.

## Tasks
- [x] Add ticket ID click event to the event delegation handler

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1029)

## CCs
@zendesk/apps-migration

## Risks
* [low] Making sure clicking either ticket ID or Title will routeTo the ticket page.
