### PR TITLE
[OFFAPPS-1023] No validation for "Start" and "Date" fields if Created/Updated not selected

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,33 @@
+(Title field)
+[OFFAPPS-XXX] Short description
+
+## Description
+Develop what, but also why this PR exists. The "Why" is as much, if not more important than the "What". I use this approach very often when I write commit messages, because if the code is clear enough it should already answer the "what" question. The "why" is often more subtle.
+
+## Tasks
+- [ ] Write tests
+
+## Implementation notes
+I don't always use this section, but I do when I find there's something particularly tricky end/or nifty in the code.
+
+## References
+[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-XXX)
+[Invision design](https://google.com.au)
+
+## Screenshots (if needed)
+### Screenshot title
+However many images needed
+
+## CCs
+Anyone specific?
+Unless there's a good reason not to:
+@zendesk/apps-migration
+If translation-related:
+@zendesk/i18n
+
+## Risks
+* [HIGH | medium | low] Does it work across browsers (including IE!)?
+* [HIGH | medium | low] Does it work in the different products (Support, Chat, Connect)?
+* [HIGH | medium | low] Are there any performance implications?
+* [HIGH | medium | low] Any security risks?
+* [HIGH | medium | low] What features does this touch?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "development",
-  "version": "1.0.0",
+  "name": "sidebarsearch",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1794,6 +1794,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+    },
+    "closest": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/closest/-/closest-0.0.1.tgz",
+      "integrity": "sha1-JtpvgLPg4X5x+A8SeCgZ6fZTSVw=",
+      "requires": {
+        "matches-selector": "0.0.1"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -6378,6 +6386,11 @@
       "requires": {
         "object-visit": "1.0.1"
       }
+    },
+    "matches-selector": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-0.0.1.tgz",
+      "integrity": "sha1-HfUmIkOuNBwaCATdMCBIJnrHE7s="
     },
     "math-expression-evaluator": {
       "version": "1.2.17",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "sidebarsearch",
   "version": "2.0.3",
   "description": "Zendesk Sidebar Search App",
-  "keywords": ["sidebar", "search"],
+  "keywords": [
+    "sidebar",
+    "search"
+  ],
   "author": "Zendesk",
   "license": "ISC",
   "scripts": {
@@ -37,6 +40,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "clean-webpack-plugin": "^0.1.18",
+    "closest": "0.0.1",
     "copy-webpack-plugin": "^4.4.1",
     "cross-env": "^5.1.6",
     "css-loader": "^0.28.9",

--- a/spec/search.spec.js
+++ b/spec/search.spec.js
@@ -165,7 +165,7 @@ describe('Search App', () => {
       })
     })
 
-    it('should toggle date fields status when advanced dropdown changes', () => {
+    it('should show date fields when date range dropdown is set, hide and reset date fields when date range dropdown is reset', () => {
       app._searchDateRangeDropdown.value = 'created'
       app._searchDateRangeDropdown.dispatchEvent(new Event('change'))
       expect(app._searchDateRange.classList.contains('show-fields')).toBe(true)

--- a/spec/search.spec.js
+++ b/spec/search.spec.js
@@ -54,7 +54,7 @@ describe('Search App', () => {
       app = new Search(CLIENT, APPDATA_WITH_CF, CONFIG)
       doTheSearchSpy = jest.spyOn(app, '_doTheSearch')
       app._initializePromise.then(() => {
-        app._keywordField.value = 'TestKeyword'
+        app.$keywordField.value = 'TestKeyword'
         done()
       })
     })
@@ -102,7 +102,7 @@ describe('Search App', () => {
 
     it('should trigger search when search form is submitted', () => {
       app._client.request.mockReturnValue(Promise.resolve(RESULTS_1))
-      app._searchForm.dispatchEvent(new Event('submit'))
+      app.$searchForm.dispatchEvent(new Event('submit'))
       expect(doTheSearchSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -110,7 +110,7 @@ describe('Search App', () => {
       app._client.request.mockReturnValue(Promise.resolve(RESULTS_1))
       document.querySelector('.suggestion').click()
       expect(doTheSearchSpy).toHaveBeenCalled()
-      expect(app._keywordField.value).toBe('cf_suggestion_1')
+      expect(app.$keywordField.value).toBe('cf_suggestion_1')
     })
 
     it('should trigger search when nav link is clicked', (done) => {
@@ -142,7 +142,7 @@ describe('Search App', () => {
 
     it('should not trigger search if search term is empty', (done) => {
       app._client.request = jest.fn()
-      app._keywordField.value = ''
+      app.$keywordField.value = ''
       app._doTheSearch(new CustomEvent('submit')).then(() => {
         expect(app._client.request).not.toHaveBeenCalled()
         done()
@@ -156,27 +156,27 @@ describe('Search App', () => {
         }
       }
       app._client.request.mockReturnValueOnce(Promise.resolve(ASSIGNEES))
-      app._searchDateRangeFrom.value = '2018-01-01'
-      app._searchDateRangeTo.value = '2018-01-31'
+      app.$searchDateRangeFrom.value = '2018-01-01'
+      app.$searchDateRangeTo.value = '2018-01-31'
       app._handleAdvancedFieldsToggle(fakeEventObject).then(() => {
-        expect(app._searchDateRangeFrom.value).toBe('')
-        expect(app._searchDateRangeTo.value).toBe('')
+        expect(app.$searchDateRangeFrom.value).toBe('')
+        expect(app.$searchDateRangeTo.value).toBe('')
         done()
       })
     })
 
     it('should show date fields when date range dropdown is set, hide and reset date fields when date range dropdown is reset', () => {
-      app._searchDateRangeDropdown.value = 'created'
-      app._searchDateRangeDropdown.dispatchEvent(new Event('change'))
-      expect(app._searchDateRange.classList.contains('show-fields')).toBe(true)
+      app.$searchDateRangeDropdown.value = 'created'
+      app.$searchDateRangeDropdown.dispatchEvent(new Event('change'))
+      expect(app.$searchDateRange.classList.contains('show-fields')).toBe(true)
 
-      app._searchDateRangeDropdown.value = ''
-      app._searchDateRangeFrom.value = '2018-01-01'
-      app._searchDateRangeTo.value = '2018-01-31'
-      app._searchDateRangeDropdown.dispatchEvent(new Event('change'))
-      expect(app._searchDateRange.classList.contains('show-fields')).toBe(false)
-      expect(app._searchDateRangeFrom.value).toBe('')
-      expect(app._searchDateRangeTo.value).toBe('')
+      app.$searchDateRangeDropdown.value = ''
+      app.$searchDateRangeFrom.value = '2018-01-01'
+      app.$searchDateRangeTo.value = '2018-01-31'
+      app.$searchDateRangeDropdown.dispatchEvent(new Event('change'))
+      expect(app.$searchDateRange.classList.contains('show-fields')).toBe(false)
+      expect(app.$searchDateRangeFrom.value).toBe('')
+      expect(app.$searchDateRangeTo.value).toBe('')
     })
 
     it('should show paginations on first page', (done) => {
@@ -261,7 +261,7 @@ describe('Search App', () => {
     })
 
     it('should compose search terms from form fields', (done) => {
-      app._keywordField.value = 'TestKeyword'
+      app.$keywordField.value = 'TestKeyword'
       expect(app._getSearchParams()).toBe('TestKeyword')
 
       document.querySelector('#type').value = 'ticket'
@@ -280,19 +280,19 @@ describe('Search App', () => {
         document.querySelector('.c-menu__item').click()
         expect(app._getSearchParams()).toBe('TestKeyword type:ticket status:new brand_id:"360000636152"')
 
-        document.querySelector('#range').value = 'created'
-        document.querySelector('#from').value = '2018-06-01'
-        document.querySelector('#to').value = '2018-06-07'
+        app.$searchDateRangeDropdown.value = 'created'
+        app.$searchDateRangeFrom.value = '2018-06-01'
+        app.$searchDateRangeTo.value = '2018-06-07'
         expect(app._getSearchParams()).toBe('TestKeyword type:ticket status:new created>2018-06-01 created<2018-06-07 brand_id:"360000636152"')
 
-        document.querySelector('#assignee').value = 'TT'
+        app.$searchForm.elements['assignee'].value = 'TT'
         expect(app._getSearchParams()).toBe('TestKeyword type:ticket status:new created>2018-06-01 created<2018-06-07 assignee:"TT" brand_id:"360000636152"')
 
-        document.querySelector('#brand-filter').value = ''
+        app.$searchBrandFilter.value = ''
         expect(app._getSearchParams()).toBe('TestKeyword type:ticket status:new created>2018-06-01 created<2018-06-07 assignee:"TT"')
 
-        document.querySelector('#type').value = 'all'
-        document.querySelector('#type').dispatchEvent(new Event('change'))
+        app.$searchTypeDropdown.value = 'all'
+        app.$searchTypeDropdown.dispatchEvent(new Event('change'))
         expect(app._getSearchParams()).toBe('TestKeyword created>2018-06-01 created<2018-06-07')
         done()
       })
@@ -334,8 +334,8 @@ describe('Search App', () => {
         .mockReturnValueOnce(Promise.resolve(BRANDS_SINGLE))
       app = new Search(CLIENT, APPDATA_WITH_CF, CONFIG)
       app._initializePromise.then(() => {
+        app.$keywordField.value = 'TestKeyword'
         done()
-        app._keywordField.value = 'TestKeyword'
       })
     })
 

--- a/src/javascript/modules/search.js
+++ b/src/javascript/modules/search.js
@@ -153,12 +153,23 @@ class Search {
    */
   _clickHandlerDispatch (event) {
     const target = event.target
-    let closestTicketLink
-    if (closest(target, '.suggestion', true)) this._handleSuggestionClick(event)
-    else if (target.dataset.index && closest(target, '.page-link', true)) this._doTheSearch(event, target.dataset.index)
+    if (closest(target, '.suggestion', true)) {
+      this._handleSuggestionClick(event)
+    }
+    else if (closest(target, '.page-link', true)) {
+      const closestPageLink = closest(target, '.page-link', true)
+      const pageIndex = closestPageLink.dataset.index
+      if (pageIndex) {
+        this._doTheSearch(event, pageIndex)
+      }
+    }
     // add an extra property dispatchTarget to click event to store the target element,
     // click event may be triggered by child elements of our target element
-    else if (closestTicketLink = closest(target, '.ticket-link', true)) this._handleResultLinkClick(Object.assign(event, {dispatchTarget: closestTicketLink}))
+    else if (closest(target, '.ticket-link', true)) {
+      const closestTicketLink = closest(target, '.ticket-link', true)
+      event.dispatchTarget = closestTicketLink
+      this._handleResultLinkClick(event)
+    }
   }
 
   /**

--- a/src/javascript/modules/search.js
+++ b/src/javascript/modules/search.js
@@ -62,17 +62,18 @@ class Search {
       await this._render('.loader', getSearchTemplate)
       this._appContainer = document.querySelector('.search-app')
       this._searchForm = this._appContainer.querySelector('.search')
-      this._keywordField = this._searchForm.querySelector('.search-box')
-      this._searchTypeDropdown = this._searchForm.querySelector('#type')
-      this._searchButton = this._searchForm.querySelector('#search-submit')
       this._searchDateRange = this._searchForm.querySelector('.date-range')
-      this._searchDateRangeDropdown = this._searchForm.querySelector('#range')
-      this._searchDateRangeFrom = this._searchForm.querySelector('#from')
-      this._searchDateRangeTo = this._searchForm.querySelector('#to')
-      this._searchAdvancedOptionsToggle = this._searchForm.querySelector('#advanced-field-toggle')
       this._searchAdvancedOptions = this._searchForm.querySelector('.advanced-options-wrapper')
-      this._searchBrandFilter = this._searchForm.querySelector('#brand-filter')
       this._searchTicketOnlySections = this._searchForm.querySelectorAll('.ticket-only')
+      this._keywordField = this._searchForm.elements['keyword']
+      this._searchTypeDropdown = this._searchForm.elements['type']
+      this._searchButton = this._searchForm.elements['search-submit']
+      this._searchDateRangeDropdown = this._searchForm.elements['range']
+      this._searchDateRangeFrom = this._searchForm.elements['from']
+      this._searchDateRangeTo = this._searchForm.elements['to']
+      this._searchAdvancedOptionsToggle = this._searchForm.elements['advanced-field-toggle']
+      this._searchBrandFilter = this._searchForm.elements['brand-filter']
+
       this._ticketStatusObj = new DropdownWithTags(
         this._states.ticketStatusOptions,
         this._searchForm.querySelector('#ticket-status'),
@@ -273,7 +274,7 @@ class Search {
       if (range && from) params.push(`${range}>${from}`)
       if (range && to) params.push(`${range}<${to}`)
       // Assignee
-      const assignee = this._searchForm.querySelector('#assignee').value
+      const assignee = this._searchForm.elements['assignee'].value
       if (this._states.showTicketFields && assignee) params.push(`assignee:"${assignee}"`)
       // Brand
       if (this._states.hasMultiplebBrands && this._searchBrandFilter.value) params.push(`brand_id:"${this._searchBrandFilter.value}"`)

--- a/src/javascript/modules/search.js
+++ b/src/javascript/modules/search.js
@@ -60,33 +60,33 @@ class Search {
     if (this._states.brands && this._states.suggestions) {
       // render application markup
       await this._render('.loader', getSearchTemplate)
-      this._appContainer = document.querySelector('.search-app')
-      this._searchForm = this._appContainer.querySelector('.search')
-      this._searchDateRange = this._searchForm.querySelector('.date-range')
-      this._searchAdvancedOptions = this._searchForm.querySelector('.advanced-options-wrapper')
-      this._searchTicketOnlySections = this._searchForm.querySelectorAll('.ticket-only')
-      this._keywordField = this._searchForm.elements['keyword']
-      this._searchTypeDropdown = this._searchForm.elements['type']
-      this._searchButton = this._searchForm.elements['search-submit']
-      this._searchDateRangeDropdown = this._searchForm.elements['range']
-      this._searchDateRangeFrom = this._searchForm.elements['from']
-      this._searchDateRangeTo = this._searchForm.elements['to']
-      this._searchAdvancedOptionsToggle = this._searchForm.elements['advanced-field-toggle']
-      this._searchBrandFilter = this._searchForm.elements['brand-filter']
+      this.$appContainer = document.querySelector('.search-app')
+      this.$searchForm = this.$appContainer.querySelector('.search')
+      this.$searchDateRange = this.$searchForm.querySelector('.date-range')
+      this.$searchAdvancedOptions = this.$searchForm.querySelector('.advanced-options-wrapper')
+      this.$searchTicketOnlySections = this.$searchForm.querySelectorAll('.ticket-only')
+      this.$keywordField = this.$searchForm.elements['keyword']
+      this.$searchTypeDropdown = this.$searchForm.elements['type']
+      this.$searchButton = this.$searchForm.elements['search-submit']
+      this.$searchDateRangeDropdown = this.$searchForm.elements['range']
+      this.$searchDateRangeFrom = this.$searchForm.elements['from']
+      this.$searchDateRangeTo = this.$searchForm.elements['to']
+      this.$searchAdvancedOptionsToggle = this.$searchForm.elements['advanced-field-toggle']
+      this.$searchBrandFilter = this.$searchForm.elements['brand-filter']
 
       this._ticketStatusObj = new DropdownWithTags(
         this._states.ticketStatusOptions,
-        this._searchForm.querySelector('#ticket-status'),
+        this.$searchForm.querySelector('#ticket-status'),
         'Ticket Status'
       )
       // events binding
-      this._appContainer.addEventListener('click', this._clickHandlerDispatch.bind(this))
-      this._searchForm.addEventListener('submit', this._doTheSearch.bind(this))
-      this._searchTypeDropdown.addEventListener('change', this._handleFilterChange.bind(this))
-      this._searchDateRangeDropdown.addEventListener('change', this._handleDateRangeChange.bind(this))
-      this._searchAdvancedOptionsToggle.addEventListener('change', this._handleAdvancedFieldsToggle.bind(this))
-      this._searchDateRangeFrom.addEventListener('invalid', this._showInvalidDateError.bind(this))
-      this._searchDateRangeTo.addEventListener('invalid', this._showInvalidDateError.bind(this))
+      this.$appContainer.addEventListener('click', this._clickHandlerDispatch.bind(this))
+      this.$searchForm.addEventListener('submit', this._doTheSearch.bind(this))
+      this.$searchTypeDropdown.addEventListener('change', this._handleFilterChange.bind(this))
+      this.$searchDateRangeDropdown.addEventListener('change', this._handleDateRangeChange.bind(this))
+      this.$searchAdvancedOptionsToggle.addEventListener('change', this._handleAdvancedFieldsToggle.bind(this))
+      this.$searchDateRangeFrom.addEventListener('invalid', this._showInvalidDateError.bind(this))
+      this.$searchDateRangeTo.addEventListener('invalid', this._showInvalidDateError.bind(this))
     }
   }
 
@@ -179,7 +179,7 @@ class Search {
     }
     Object.assign(this._states, {showAdvancedOptions: event.target.checked})
     if (!event.target.checked) this._resetDateFields()
-    this._searchAdvancedOptions.classList.toggle('u-display-block')
+    this.$searchAdvancedOptions.classList.toggle('u-display-block')
     return resizeContainer(this._client, MAX_HEIGHT)
   }
 
@@ -190,7 +190,7 @@ class Search {
   async _handleFilterChange (event) {
     const isTicketSelected = event.target.value === 'ticket'
     Object.assign(this._states, {showTicketFields: isTicketSelected})
-    Array.prototype.forEach.call(this._searchTicketOnlySections, (field) => {
+    Array.prototype.forEach.call(this.$searchTicketOnlySections, (field) => {
       field.classList[isTicketSelected ? 'add' : 'remove']('u-display-block')
     })
     return resizeContainer(this._client, MAX_HEIGHT)
@@ -202,9 +202,9 @@ class Search {
    */
   async _handleDateRangeChange (event) {
     if (event.target.value) {
-      this._searchDateRange.classList.add('show-fields')
+      this.$searchDateRange.classList.add('show-fields')
     } else {
-      this._searchDateRange.classList.remove('show-fields')
+      this.$searchDateRange.classList.remove('show-fields')
       this._resetDateFields()
     }
     return this._hideInvalidDateError()
@@ -217,7 +217,7 @@ class Search {
    */
   async _doTheSearch (event, pageIndex = 1) {
     event.preventDefault()
-    if (this._searchForm.checkValidity()) {
+    if (this.$searchForm.checkValidity()) {
       this._hideInvalidDateError()
       this._showLoadingButton()
       const results = await this._client.request({
@@ -236,7 +236,7 @@ class Search {
    * @param {Event} event
    */
   _handleSuggestionClick (event) {
-    this._keywordField.value = event.target.textContent
+    this.$keywordField.value = event.target.textContent
     this._doTheSearch(event)
   }
 
@@ -255,8 +255,8 @@ class Search {
    */
   _getSearchParams () {
     const params = []
-    const searchType = this._searchTypeDropdown.value
-    const searchTerm = this._keywordField.value
+    const searchType = this.$searchTypeDropdown.value
+    const searchTerm = this.$keywordField.value
     if (searchType !== 'all') {
       params.push(`type:${searchType}`)
     }
@@ -268,16 +268,16 @@ class Search {
         })
       }
       // Created
-      const range = this._searchDateRangeDropdown.value
-      const from = this._searchDateRangeFrom.value
-      const to = this._searchDateRangeTo.value
+      const range = this.$searchDateRangeDropdown.value
+      const from = this.$searchDateRangeFrom.value
+      const to = this.$searchDateRangeTo.value
       if (range && from) params.push(`${range}>${from}`)
       if (range && to) params.push(`${range}<${to}`)
       // Assignee
-      const assignee = this._searchForm.elements['assignee'].value
+      const assignee = this.$searchForm.elements['assignee'].value
       if (this._states.showTicketFields && assignee) params.push(`assignee:"${assignee}"`)
       // Brand
-      if (this._states.hasMultiplebBrands && this._searchBrandFilter.value) params.push(`brand_id:"${this._searchBrandFilter.value}"`)
+      if (this._states.hasMultiplebBrands && this.$searchBrandFilter.value) params.push(`brand_id:"${this.$searchBrandFilter.value}"`)
     }
     if (params.length) return `${searchTerm} ${params.join(' ')}`
     return searchTerm
@@ -351,7 +351,7 @@ class Search {
         isError: true
       }
     )
-    this._searchButton && this._hideLoadingButton()
+    this.$searchButton && this._hideLoadingButton()
     this._render(container, getResultsTemplate)
   }
 
@@ -359,8 +359,8 @@ class Search {
    * Reset Date fields
    */
   _resetDateFields () {
-    this._searchDateRangeFrom.value = ''
-    this._searchDateRangeTo.value = ''
+    this.$searchDateRangeFrom.value = ''
+    this.$searchDateRangeTo.value = ''
     this._hideInvalidDateError()
   }
 
@@ -371,7 +371,7 @@ class Search {
    * @return {Promise} will resolved after resize
    */
   _showInvalidDateError (event) {
-    this._searchDateRange.classList.add('show-error')
+    this.$searchDateRange.classList.add('show-error')
     return resizeContainer(this._client, MAX_HEIGHT)
   }
 
@@ -380,7 +380,7 @@ class Search {
    * @return {Promise} will resolved after resize
    */
   _hideInvalidDateError () {
-    this._searchDateRange.classList.remove('show-error')
+    this.$searchDateRange.classList.remove('show-error')
     return resizeContainer(this._client, MAX_HEIGHT)
   }
 
@@ -388,14 +388,14 @@ class Search {
    * Set search button to be loading status
    */
   _showLoadingButton () {
-    this._searchButton.classList.add('is-loading')
+    this.$searchButton.classList.add('is-loading')
   }
 
   /**
    * Reset search button to be normal status
    */
   _hideLoadingButton () {
-    this._searchButton.classList.remove('is-loading')
+    this.$searchButton.classList.remove('is-loading')
   }
 
   /**

--- a/src/javascript/modules/search.js
+++ b/src/javascript/modules/search.js
@@ -152,9 +152,12 @@ class Search {
    */
   _clickHandlerDispatch (event) {
     const target = event.target
+    let closestTicketLink
     if (closest(target, '.suggestion', true)) this._handleSuggestionClick(event)
     else if (target.dataset.index && closest(target, '.page-link', true)) this._doTheSearch(event, target.dataset.index)
-    else if (closest(target, '.ticket-link', true)) this._handleResultLinkClick(event)
+    // add an extra property dispatchTarget to click event to store the target element,
+    // click event may be triggered by child elements of our target element
+    else if (closestTicketLink = closest(target, '.ticket-link', true)) this._handleResultLinkClick(Object.assign(event, {dispatchTarget: closestTicketLink}))
   }
 
   /**
@@ -242,7 +245,7 @@ class Search {
    */
   _handleResultLinkClick (event) {
     event.preventDefault()
-    this._client.invoke('routeTo', 'ticket', event.target.dataset.id)
+    this._client.invoke('routeTo', 'ticket', event.dispatchTarget.dataset.id)
   }
 
   /**

--- a/src/javascript/modules/search.js
+++ b/src/javascript/modules/search.js
@@ -8,6 +8,7 @@ import getResultsTemplate from '../../templates/results'
 import getSearchTemplate from '../../templates/search'
 import getAssigneesTemplate from '../../templates/assignees'
 import DropdownWithTags from '../lib/dropdown_with_tags'
+import closest from 'closest'
 
 const PER_PAGE = 5
 const MAX_HEIGHT = 1000
@@ -151,9 +152,9 @@ class Search {
    */
   _clickHandlerDispatch (event) {
     const target = event.target
-    if (target.classList.contains('suggestion')) this._handleSuggestionClick(event)
-    else if (target.classList.contains('page-link') && target.dataset.index) this._doTheSearch(event, target.dataset.index)
-    else if (target.classList.contains('ticket-link') || target.parentNode.classList.contains('ticket-link')) this._handleResultLinkClick(event)
+    if (closest(target, '.suggestion', true)) this._handleSuggestionClick(event)
+    else if (target.dataset.index && closest(target, '.page-link', true)) this._doTheSearch(event, target.dataset.index)
+    else if (closest(target, '.ticket-link', true)) this._handleResultLinkClick(event)
   }
 
   /**
@@ -361,6 +362,8 @@ class Search {
 
   /**
    * Show error message when date field value is invalid
+   * !! Temporary skip integration testing for this because form constraint validation is not well supported in jsdom as for now
+   * https://github.com/jsdom/jsdom/issues/544
    * @return {Promise} will resolved after resize
    */
   _showInvalidDateError (event) {

--- a/src/javascript/modules/search.js
+++ b/src/javascript/modules/search.js
@@ -173,7 +173,7 @@ class Search {
       this._hideLoadingButton()
     }
     Object.assign(this._states, {showAdvancedOptions: event.target.checked})
-    event.target.checked ? this._toggleDateFieldsStatus(false) : this._toggleDateFieldsStatus(true)
+    if(!event.target.checked) this._resetDateFields()
     this._searchAdvancedOptions.classList.toggle('u-display-block')
     return resizeContainer(this._client, MAX_HEIGHT)
   }
@@ -198,10 +198,9 @@ class Search {
   async _handleDateRangeChange (event) {
     if (event.target.value) {
       this._searchDateRange.classList.add('show-fields')
-      this._toggleDateFieldsStatus(false)
     } else {
       this._searchDateRange.classList.remove('show-fields')
-      this._toggleDateFieldsStatus(true)
+      this._resetDateFields()
     }
     return this._hideInvalidDateError()
   }
@@ -352,12 +351,12 @@ class Search {
   }
 
   /**
-   * Toggle Date fields(Start/End) status
-   * @param {Boolean} isDisabled
+   * Reset Date fields
    */
-  _toggleDateFieldsStatus (isDisabled) {
-    this._searchDateRangeFrom.disabled = isDisabled
-    this._searchDateRangeTo.disabled = isDisabled
+  _resetDateFields () {
+    this._searchDateRangeFrom.value = ''
+    this._searchDateRangeTo.value = ''
+    this._hideInvalidDateError()
   }
 
   /**

--- a/src/javascript/modules/search.js
+++ b/src/javascript/modules/search.js
@@ -177,7 +177,7 @@ class Search {
       this._hideLoadingButton()
     }
     Object.assign(this._states, {showAdvancedOptions: event.target.checked})
-    if(!event.target.checked) this._resetDateFields()
+    if (!event.target.checked) this._resetDateFields()
     this._searchAdvancedOptions.classList.toggle('u-display-block')
     return resizeContainer(this._client, MAX_HEIGHT)
   }

--- a/src/main.css
+++ b/src/main.css
@@ -22,6 +22,10 @@
   overflow: hidden;
   padding: 0 3px;
 }
+input[type="text"]:invalid,
+input[type="date"]:invalid {
+  border-color: var(--zd-color-red-400);
+}
 #search-submit {
   height: 30px; 
   width: 30px;
@@ -68,6 +72,27 @@ div.c-txt__input {
 .advanced-options-wrapper,
 .ticket-only {
   display: none;
+}
+.date-range {
+  border-bottom: 1px solid var(--zd-color-grey-300);
+  .date-range--error,
+  .date-range--fields {
+    display: none;
+  }
+  &.show-fields {
+    .date-range--fields {
+      display: flex;
+    }
+  }
+  &.show-error {
+    .date-range--error {
+      display: block;
+    }
+  }
+  .col{
+    width: calc(50% - 20px)
+  }
+
 }
 #ticket-status {
   .c-menu {

--- a/src/main.css
+++ b/src/main.css
@@ -89,7 +89,7 @@ div.c-txt__input {
       display: block;
     }
   }
-  .col{
+  .col {
     width: calc(50% - 20px)
   }
 

--- a/src/templates/results.js
+++ b/src/templates/results.js
@@ -5,7 +5,7 @@ const getTicketMarkup = (o) => {
     `
     <tr class="c-table__row">
       <td class="c-table__row__cell u-position-relative">
-        <a href class="ticket-link" data-id="${o.id}"><b data-id="${o.id}">#${o.id}</b> ${escape(o.subject)}</a>
+        <a href class="ticket-link" data-id="${o.id}"><b>#${o.id}</b> ${escape(o.subject)}</a>
         <div class="c-tooltip c-tooltip--large c-arrow c-arrow--l">${escape(o.description)}</div>
       </td>
       <td class="type c-table__row__cell u-ta-right">${I18n.t('search.result_type.ticket')}</td>

--- a/src/templates/search.js
+++ b/src/templates/search.js
@@ -73,11 +73,11 @@ export default function (args) {
           <div class="row date-range--fields">
             <div class="col">
               <label class="c-txt__label c-txt__label--sm" for="from">${I18n.t('search.filter.date_start')}</label>
-              <input type="text" id="from" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
+              <input type="date" id="from" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
             </div>
             <div class="col">
               <label class="c-txt__label c-txt__label--sm" for="to">${I18n.t('search.filter.date_end')}</label>
-              <input type="text" id="to" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
+              <input type="date" id="to" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
             </div>
           </div>
           <small class="c-txt__message c-txt__message--error date-range--error u-mv-sm">${I18n.t('search.filter.date_error')}</small>

--- a/src/templates/search.js
+++ b/src/templates/search.js
@@ -46,8 +46,8 @@ export default function (args) {
       </fieldset>
       <fieldset class="u-mb-sm">
         <div class="c-txt__input c-txt__input--sm u-display-flex">
-          <input class="c-txt__input c-txt__input--bare c-txt__input--sm search-box" placeholder="${I18n.t('search.term.placeholder')}" type="text" autocomplete="off" required>
-          <button type="submit" id="search-submit" class="c-btn c-btn--icon c-btn--sm c-btn--basic c-btn--muted">
+          <input class="c-txt__input c-txt__input--bare c-txt__input--sm search-box" name="keyword" placeholder="${I18n.t('search.term.placeholder')}" type="text" autocomplete="off" required>
+          <button type="submit" id="search-submit" name="search-submit" class="c-btn c-btn--icon c-btn--sm c-btn--basic c-btn--muted">
             <svg viewBox="0 0 16 16" id="zd-svg-icon-16-search-stroke" width="16" height="16"><circle cx="6" cy="6" r="5.5" fill="none" stroke="currentColor"></circle><path stroke="currentColor" stroke-linecap="round" d="M15 15l-5-5"></path></svg>
           </button>
         </div>
@@ -57,7 +57,7 @@ export default function (args) {
         ${getSuggestionsListMarkup(args.suggestions)}
       </fieldset>
       <fieldset class="u-mb-sm u-ta-right c-chk">
-        <input class="c-chk__input" id="advanced-field-toggle" type="checkbox">
+        <input class="c-chk__input" id="advanced-field-toggle" name="advanced-field-toggle" type="checkbox">
         <label class="c-chk__label__unchecked" for="advanced-field-toggle">${I18n.t('search.options.advanced')}</label>
         <label class="c-chk__label__checked" for="advanced-field-toggle">${I18n.t('search.options.basic')}</label>
       </fieldset>
@@ -73,11 +73,11 @@ export default function (args) {
           <div class="row date-range--fields">
             <div class="col">
               <label class="c-txt__label c-txt__label--sm" for="from">${I18n.t('search.filter.date_start')}</label>
-              <input type="date" id="from" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
+              <input type="date" id="from" name="from" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
             </div>
             <div class="col">
               <label class="c-txt__label c-txt__label--sm" for="to">${I18n.t('search.filter.date_end')}</label>
-              <input type="date" id="to" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
+              <input type="date" id="to" name="to" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
             </div>
           </div>
           <small class="c-txt__message c-txt__message--error date-range--error u-mv-sm">${I18n.t('search.filter.date_error')}</small>

--- a/src/templates/search.js
+++ b/src/templates/search.js
@@ -32,7 +32,7 @@ export default function (args) {
   return (
     `
   <div class="search-app">
-    <form action="" class="search">
+    <form action="" class="search" novalidate>
       <fieldset class="u-mb-sm">
         <label class="c-txt__label c-txt__label--sm" for="type">${I18n.t('search.search')}</label>
         <select name="type" id="type" class="c-txt__input c-txt__input--select c-txt__input--sm">
@@ -46,8 +46,8 @@ export default function (args) {
       </fieldset>
       <fieldset class="u-mb-sm">
         <div class="c-txt__input c-txt__input--sm u-display-flex">
-          <input class="c-txt__input c-txt__input--bare c-txt__input--sm search-box" placeholder="${I18n.t('search.term.placeholder')}" type="text" autocomplete="off">
-          <button type="button" id="search-submit" class="c-btn c-btn--icon c-btn--sm c-btn--basic c-btn--muted">
+          <input class="c-txt__input c-txt__input--bare c-txt__input--sm search-box" placeholder="${I18n.t('search.term.placeholder')}" type="text" autocomplete="off" required>
+          <button type="submit" id="search-submit" class="c-btn c-btn--icon c-btn--sm c-btn--basic c-btn--muted">
             <svg viewBox="0 0 16 16" id="zd-svg-icon-16-search-stroke" width="16" height="16"><circle cx="6" cy="6" r="5.5" fill="none" stroke="currentColor"></circle><path stroke="currentColor" stroke-linecap="round" d="M15 15l-5-5"></path></svg>
           </button>
         </div>
@@ -63,23 +63,24 @@ export default function (args) {
       </fieldset>
       <div class="advanced-options-wrapper">
         <fieldset class="u-mb-sm u-position-relative ticket-only" id="ticket-status"></fieldset>
-        <fieldset class="u-mb-sm">
+        <fieldset class="u-mb-sm u-pb-sm date-range">
           <label class="c-txt__label c-txt__label--sm" for="range">${I18n.t('search.filter.date_range')}</label>
           <select name="range" id="range" class="c-txt__input c-txt__input--select c-txt__input--sm u-mb-sm">
-            <option value="">-</option>
+            <option value="">${I18n.t('search.filter.none')}</option>
             <option value="created">${I18n.t('search.filter.created')}</option>
             <option value="updated">${I18n.t('search.filter.updated')}</option>
           </select>
-          <div class="row">
+          <div class="row date-range--fields">
             <div class="col">
               <label class="c-txt__label c-txt__label--sm" for="from">${I18n.t('search.filter.date_start')}</label>
-              <input type="text" id="from" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD">
+              <input type="text" id="from" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
             </div>
             <div class="col">
               <label class="c-txt__label c-txt__label--sm" for="to">${I18n.t('search.filter.date_end')}</label>
-              <input type="text" id="to" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD">
+              <input type="text" id="to" class="c-txt__input c-txt__input--sm" placeholder="YYYY-MM-DD" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
             </div>
           </div>
+          <small class="c-txt__message c-txt__message--error date-range--error u-mv-sm">${I18n.t('search.filter.date_error')}</small>
         </fieldset>
         <fieldset class="u-mb-sm ticket-only">
           <label class="c-txt__label c-txt__label--sm" for="assignee">${I18n.t('search.user.assignee')}</label>


### PR DESCRIPTION
[OFFAPPS-1023] No validation for "Start" and "Date" fields if Created/Updated not selected

## Description
"Date range", "Start" and "End" fields don't have validation on values and logics. @m-lai has created a new design to improve the UX. 

## Tasks
- [x] Change "Start" and "End" fields to be type `date`, adding validations for browsers not support Form constraint API
- [x] Update as per new UX design(both looking and feature)
- [x] Write tests

## Implementation notes
[closest](https://www.npmjs.com/package/closest) is used to handle event delegation

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1023)
[Invision design](https://zendesk.invisionapp.com/share/8DJQOTNNT9M#/screens/299998016_sidebar-Search-App-Specs)

## Screenshots
#### Date range none
![None](https://lh3.googleusercontent.com/u/0/d/1CDEGNjqU6NNG2WCRjtcA1it7YdQYN9Od=w4346-h2804-iv1)
#### Safari
![Safari](https://lh3.googleusercontent.com/u/0/d/1LkAragdcxgcy2SmJmms5IqRm4iOYk2Ps=w4600-h2680-iv1)
#### Chrome
![Chrome](https://lh3.googleusercontent.com/u/0/d/1_sMc3p8YtStwiNgiV7Snj_6C9_5ZNNpl=w4600-h2680-iv1)

## CCs
@m-lai 
@zendesk/apps-migration

## Risks
* [medium] Regression testing and new feature testing
